### PR TITLE
feat: add community and eventbrite event sync endpoints

### DIFF
--- a/app/api/cron/community-events-sync/route.ts
+++ b/app/api/cron/community-events-sync/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runCommunityFeedSync } from "@/app/lib/integrations/communityFeedSync";
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (
+    !process.env.CRON_SECRET ||
+    authHeader !== `Bearer ${process.env.CRON_SECRET}`
+  ) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await runCommunityFeedSync();
+
+    return NextResponse.json(
+      {
+        msg: result.message,
+        feeds: result.feeds,
+        totals: result.totals,
+      },
+      { status: result.status },
+    );
+  } catch (error) {
+    console.error("/api/cron/community-events-sync error:", error);
+    return NextResponse.json(
+      { error: "Failed to run scheduled community event sync" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/cron/events-prune/route.ts
+++ b/app/api/cron/events-prune/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { prunePastEvents } from "@/app/lib/integrations/eventPrune";
+
+function revalidateEventPages() {
+  try {
+    revalidatePath("/events");
+    revalidatePath("/student/events");
+    revalidatePath("/events/manage");
+  } catch (error) {
+    console.warn("Event revalidation failed:", error);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (
+    !process.env.CRON_SECRET ||
+    authHeader !== `Bearer ${process.env.CRON_SECRET}`
+  ) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await prunePastEvents();
+    revalidateEventPages();
+
+    return NextResponse.json(
+      {
+        msg: "Past event prune completed",
+        ...result,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("/api/cron/events-prune error:", error);
+    return NextResponse.json(
+      { error: "Failed to prune past events" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/events/community/reset-sync/route.ts
+++ b/app/api/events/community/reset-sync/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import pool from "@/app/lib/db";
+import { runCommunityFeedSync } from "@/app/lib/integrations/communityFeedSync";
+
+function revalidateEventPages() {
+  try {
+    revalidatePath("/events");
+    revalidatePath("/student/events");
+    revalidatePath("/events/manage");
+  } catch (error) {
+    console.warn("Event revalidation failed:", error);
+  }
+}
+
+export async function POST() {
+  try {
+    const deleted = await pool.query(
+      "DELETE FROM events WHERE source = 'community-feed' RETURNING id",
+    );
+    const deletedCount = deleted.rowCount ?? 0;
+
+    const syncResult = await runCommunityFeedSync();
+
+    revalidateEventPages();
+
+    return NextResponse.json(
+      {
+        msg: syncResult.message,
+        deleted: deletedCount,
+        deletedScope: "community-feed",
+        feeds: syncResult.feeds,
+        keywords: syncResult.keywords,
+        locations: syncResult.locations,
+        fetched: syncResult.totals.fetched,
+        matched: syncResult.totals.matched,
+        created: syncResult.totals.created,
+        updated: syncResult.totals.updated,
+        unchanged: syncResult.totals.unchanged,
+      },
+      { status: syncResult.status },
+    );
+  } catch (error) {
+    console.error("/api/events/community/reset-sync error:", error);
+    return NextResponse.json(
+      { error: "Failed to delete and resync events" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/events/community/sync/route.ts
+++ b/app/api/events/community/sync/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { runCommunityFeedSync } from "@/app/lib/integrations/communityFeedSync";
+
+export async function POST() {
+  try {
+    const result = await runCommunityFeedSync();
+
+    return NextResponse.json(
+      {
+        msg: result.message,
+        feeds: result.feeds,
+        keywords: result.keywords,
+        locations: result.locations,
+        fetched: result.totals.fetched,
+        matched: result.totals.matched,
+        created: result.totals.created,
+        updated: result.totals.updated,
+        unchanged: result.totals.unchanged,
+      },
+      { status: result.status },
+    );
+  } catch (error) {
+    console.error("/api/events/community/sync error:", error);
+    return NextResponse.json(
+      { error: "Failed to sync community event feeds" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/events/eventbrite/reset-sync/route.ts
+++ b/app/api/events/eventbrite/reset-sync/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import pool from "@/app/lib/db";
+import { runEventbriteGrabberSync } from "@/app/lib/integrations/eventbriteGrabberSync";
+
+function revalidateEventPages() {
+  try {
+    revalidatePath("/events");
+    revalidatePath("/student/events");
+    revalidatePath("/events/manage");
+  } catch (error) {
+    console.warn("Event revalidation failed:", error);
+  }
+}
+
+export async function POST() {
+  try {
+    const deleted = await pool.query(
+      "DELETE FROM events WHERE source = 'eventbrite' RETURNING id",
+    );
+    const deletedCount = deleted.rowCount ?? 0;
+
+    const syncResult = await runEventbriteGrabberSync();
+
+    revalidateEventPages();
+
+    return NextResponse.json(
+      {
+        msg: syncResult.message,
+        deleted: deletedCount,
+        deletedScope: "eventbrite",
+        fetched: syncResult.fetched,
+        created: syncResult.created,
+        updated: syncResult.updated,
+        unchanged: syncResult.unchanged,
+        attemptedQueries: syncResult.attemptedQueries,
+        failedQueries: syncResult.failedQueries,
+        totalQueries: syncResult.totalQueries,
+        chunkIndex: syncResult.chunkIndex,
+        chunkCount: syncResult.chunkCount,
+        error: syncResult.error,
+      },
+      { status: syncResult.ok ? 200 : 500 },
+    );
+  } catch (error) {
+    console.error("/api/events/eventbrite/reset-sync error:", error);
+    return NextResponse.json(
+      { error: "Failed to delete and resync Eventbrite events" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/events/eventbrite/sync/route.ts
+++ b/app/api/events/eventbrite/sync/route.ts
@@ -1,15 +1,19 @@
-import { NextRequest, NextResponse } from "next/server";
-import { auth0 } from "@/lib/auth0";
-import { runEventbriteGrabberSync } from "@/app/lib/integrations/eventbriteGrabberSync";
+import { NextResponse } from "next/server";
+import {
+  runEventbriteGrabberSync,
+  type EventbriteSyncRequest,
+} from "@/app/lib/integrations/eventbriteGrabberSync";
 
-export async function POST(_request: NextRequest) {
+export async function POST(request: Request) {
   try {
-    const session = await auth0.getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    let body: EventbriteSyncRequest = {};
+    try {
+      body = (await request.json()) as EventbriteSyncRequest;
+    } catch {
+      body = {};
     }
 
-    const result = await runEventbriteGrabberSync();
+    const result = await runEventbriteGrabberSync(body);
 
     return NextResponse.json(
       {
@@ -19,6 +23,11 @@ export async function POST(_request: NextRequest) {
         created: result.created,
         updated: result.updated,
         unchanged: result.unchanged,
+        attemptedQueries: result.attemptedQueries,
+        failedQueries: result.failedQueries,
+        totalQueries: result.totalQueries,
+        chunkIndex: result.chunkIndex,
+        chunkCount: result.chunkCount,
         error: result.error,
       },
       { status: result.ok ? 200 : 500 },

--- a/app/api/internships/greenhouse/sync/route.ts
+++ b/app/api/internships/greenhouse/sync/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth0 } from "@/lib/auth0";
 import {
   type GreenhouseSyncRequest,
   runGreenhouseSync,
@@ -7,11 +6,6 @@ import {
 
 export async function POST(request: NextRequest) {
   try {
-    const session = await auth0.getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     let body: GreenhouseSyncRequest = {};
     try {
       body = (await request.json()) as {

--- a/app/api/internships/lever/sync/route.ts
+++ b/app/api/internships/lever/sync/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth0 } from "@/lib/auth0";
 import {
   type LeverSyncRequest,
   runLeverSync,
@@ -7,11 +6,6 @@ import {
 
 export async function POST(request: NextRequest) {
   try {
-    const session = await auth0.getSession();
-    if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     let body: LeverSyncRequest = {};
     try {
       body = (await request.json()) as {

--- a/app/events/ManageEventsClient.tsx
+++ b/app/events/ManageEventsClient.tsx
@@ -121,6 +121,47 @@ function validateFormState(form: EventFormState): string | null {
   return null;
 }
 
+async function parseApiPayload(response: Response): Promise<{
+  json: Record<string, unknown> | null;
+  text: string;
+}> {
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  const bodyText = await response.text();
+
+  if (!contentType.includes("application/json")) {
+    return { json: null, text: bodyText };
+  }
+
+  try {
+    const parsed = JSON.parse(bodyText) as Record<string, unknown>;
+    return { json: parsed, text: bodyText };
+  } catch {
+    return { json: null, text: bodyText };
+  }
+}
+
+function extractResponseError(
+  response: Response,
+  payload: { json: Record<string, unknown> | null; text: string },
+  fallback: string,
+): string {
+  if (payload.json && typeof payload.json.error === "string") {
+    return payload.json.error;
+  }
+
+  if (payload.text.trim().toLowerCase().startsWith("<!doctype") || payload.text.includes("<html")) {
+    if (response.status === 401 || response.status === 403) {
+      return "Your session is no longer authorized. Please sign in again.";
+    }
+    if (response.status === 404) {
+      return "Sync endpoint not found. Please restart the dev server and try again.";
+    }
+    return "Received an HTML response instead of JSON. Please refresh and try again.";
+  }
+
+  return fallback;
+}
+
 function ownerLabel(item: ManagedEventItem, currentUserSub: string): string {
   if (item.createdBy && item.createdBy === currentUserSub) {
     return "You";
@@ -152,7 +193,14 @@ export default function ManageEventsClient({
   const [savingId, setSavingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [syncingCommunity, setSyncingCommunity] = useState(false);
+  const [resettingAndSyncingCommunity, setResettingAndSyncingCommunity] = useState(false);
+  const [communitySyncFeedback, setCommunitySyncFeedback] = useState<{
+    tone: "success" | "error";
+    text: string;
+  } | null>(null);
   const [syncingEventbrite, setSyncingEventbrite] = useState(false);
+  const [resettingAndSyncingEventbrite, setResettingAndSyncingEventbrite] = useState(false);
   const [syncFeedback, setSyncFeedback] = useState<{
     tone: "success" | "error";
     text: string;
@@ -388,44 +436,145 @@ export default function ManageEventsClient({
     }
   };
 
+  const syncEventbriteChunk = async (body: Record<string, unknown>) => {
+    const res = await fetch("/api/events/eventbrite/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const payload = await parseApiPayload(res);
+    const data = (payload.json ?? {}) as {
+      error?: string;
+      msg?: string;
+      fetched?: number;
+      created?: number;
+      updated?: number;
+      unchanged?: number;
+      attemptedQueries?: number;
+      failedQueries?: number;
+      totalQueries?: number;
+      chunkIndex?: number;
+      chunkCount?: number;
+    };
+
+    return { res, payload, data };
+  };
+
+  const runRemainingEventbriteChunks = async (initial: {
+    chunkIndex?: number;
+    chunkCount?: number;
+    fetched?: number;
+    created?: number;
+    updated?: number;
+    unchanged?: number;
+    attemptedQueries?: number;
+    failedQueries?: number;
+  }) => {
+    const initialChunkIndex =
+      typeof initial.chunkIndex === "number" ? initial.chunkIndex : 0;
+    const initialChunkCount =
+      typeof initial.chunkCount === "number" ? initial.chunkCount : 1;
+
+    let fetched = initial.fetched ?? 0;
+    let created = initial.created ?? 0;
+    let updated = initial.updated ?? 0;
+    let unchanged = initial.unchanged ?? 0;
+    let attemptedQueries = initial.attemptedQueries ?? 0;
+    let failedQueries = initial.failedQueries ?? 0;
+    let completedChunks = 1;
+
+    if (initialChunkCount > 1) {
+      for (let offset = 1; offset < initialChunkCount; offset += 1) {
+        const chunkIndex = (initialChunkIndex + offset) % initialChunkCount;
+        const { res, payload, data } = await syncEventbriteChunk({ chunkIndex });
+
+        if (!res.ok || !payload.json) {
+          return {
+            ok: false as const,
+            error: extractResponseError(
+              res,
+              payload,
+              `Failed while syncing chunk ${chunkIndex + 1}/${initialChunkCount}.`,
+            ),
+            fetched,
+            created,
+            updated,
+            unchanged,
+            attemptedQueries,
+            failedQueries,
+            completedChunks,
+            chunkCount: initialChunkCount,
+          };
+        }
+
+        fetched += data.fetched ?? 0;
+        created += data.created ?? 0;
+        updated += data.updated ?? 0;
+        unchanged += data.unchanged ?? 0;
+        attemptedQueries += data.attemptedQueries ?? 0;
+        failedQueries += data.failedQueries ?? 0;
+        completedChunks += 1;
+      }
+    }
+
+    return {
+      ok: true as const,
+      fetched,
+      created,
+      updated,
+      unchanged,
+      attemptedQueries,
+      failedQueries,
+      completedChunks,
+      chunkCount: initialChunkCount,
+    };
+  };
+
   const handleEventbriteSync = async () => {
     setError(null);
     setSyncFeedback(null);
     setSyncingEventbrite(true);
 
     try {
-      const res = await fetch("/api/events/eventbrite/sync", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      });
-
-      const data = (await res.json()) as {
-        error?: string;
-        msg?: string;
-        fetched?: number;
-        created?: number;
-        updated?: number;
-        unchanged?: number;
-      };
+      const { res, payload, data } = await syncEventbriteChunk({});
 
       if (!res.ok) {
         setSyncFeedback({
           tone: "error",
-          text: data?.error || "Failed to grab Eventbrite events.",
+          text: extractResponseError(res, payload, "Failed to grab Eventbrite events."),
+        });
+        return;
+      }
+
+      if (!payload.json) {
+        setSyncFeedback({
+          tone: "error",
+          text: "Sync endpoint returned an unexpected response format.",
+        });
+        return;
+      }
+
+      const rollup = await runRemainingEventbriteChunks(data);
+
+      if (!rollup.ok) {
+        setSyncFeedback({
+          tone: "error",
+          text: `${rollup.error} Partial totals: ${rollup.fetched} fetched, ${rollup.created} created, ${rollup.updated} updated, ${rollup.unchanged} unchanged.`,
         });
         return;
       }
 
       const summary = [
-        `${data?.fetched ?? 0} fetched`,
-        `${data?.created ?? 0} created`,
-        `${data?.updated ?? 0} updated`,
-        `${data?.unchanged ?? 0} unchanged`,
+        `${rollup.fetched} fetched`,
+        `${rollup.created} created`,
+        `${rollup.updated} updated`,
+        `${rollup.unchanged} unchanged`,
       ].join(", ");
 
       setSyncFeedback({
         tone: "success",
-        text: `${data?.msg || "Eventbrite grab completed."} ${summary}.`,
+        text: `${data?.msg || "Eventbrite grab completed."} ${summary}. chunks ${rollup.completedChunks}/${rollup.chunkCount} (queries ${rollup.attemptedQueries}, ${rollup.failedQueries} empty/failed).`,
       });
 
       try {
@@ -444,41 +593,332 @@ export default function ManageEventsClient({
     }
   };
 
+  const handleResetAndResyncEventbrite = async () => {
+    if (
+      !window.confirm(
+        "Delete all Eventbrite events and resync across all chunks? This only removes source='eventbrite' rows.",
+      )
+    ) {
+      return;
+    }
+
+    setError(null);
+    setSyncFeedback(null);
+    setResettingAndSyncingEventbrite(true);
+
+    try {
+      const res = await fetch("/api/events/eventbrite/reset-sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const payload = await parseApiPayload(res);
+      const data = (payload.json ?? {}) as {
+        error?: string;
+        msg?: string;
+        deleted?: number;
+        fetched?: number;
+        created?: number;
+        updated?: number;
+        unchanged?: number;
+        attemptedQueries?: number;
+        failedQueries?: number;
+        chunkIndex?: number;
+        chunkCount?: number;
+      };
+
+      if (!res.ok) {
+        setSyncFeedback({
+          tone: "error",
+          text: extractResponseError(
+            res,
+            payload,
+            "Failed to delete and resync Eventbrite events.",
+          ),
+        });
+        return;
+      }
+
+      if (!payload.json) {
+        setSyncFeedback({
+          tone: "error",
+          text: "Eventbrite reset sync endpoint returned an unexpected response format.",
+        });
+        return;
+      }
+
+      const rollup = await runRemainingEventbriteChunks(data);
+      if (!rollup.ok) {
+        setSyncFeedback({
+          tone: "error",
+          text: `${rollup.error} Partial totals after delete: ${rollup.fetched} fetched, ${rollup.created} created, ${rollup.updated} updated, ${rollup.unchanged} unchanged.`,
+        });
+        return;
+      }
+
+      const summary = [
+        `${data.deleted ?? 0} deleted`,
+        `${rollup.fetched} fetched`,
+        `${rollup.created} created`,
+        `${rollup.updated} updated`,
+        `${rollup.unchanged} unchanged`,
+      ].join(", ");
+
+      setSyncFeedback({
+        tone: "success",
+        text: `${data.msg || "Eventbrite delete and resync completed."} ${summary}. chunks ${rollup.completedChunks}/${rollup.chunkCount} (queries ${rollup.attemptedQueries}, ${rollup.failedQueries} empty/failed).`,
+      });
+
+      try {
+        router.refresh();
+      } catch {
+        window.location.reload();
+      }
+    } catch (syncError: unknown) {
+      const message =
+        syncError instanceof Error ? syncError.message : "Unexpected error";
+      setSyncFeedback({
+        tone: "error",
+        text: message,
+      });
+    } finally {
+      setResettingAndSyncingEventbrite(false);
+    }
+  };
+
+  const handleCommunitySync = async () => {
+    setError(null);
+    setCommunitySyncFeedback(null);
+    setSyncingCommunity(true);
+
+    try {
+      const res = await fetch("/api/events/community/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const payload = await parseApiPayload(res);
+      const data = (payload.json ?? {}) as {
+        error?: string;
+        msg?: string;
+        fetched?: number;
+        matched?: number;
+        created?: number;
+        updated?: number;
+        unchanged?: number;
+      };
+
+      if (!res.ok) {
+        setCommunitySyncFeedback({
+          tone: "error",
+          text: extractResponseError(res, payload, "Failed to sync community event feeds."),
+        });
+        return;
+      }
+
+      if (!payload.json) {
+        setCommunitySyncFeedback({
+          tone: "error",
+          text: "Sync endpoint returned an unexpected response format.",
+        });
+        return;
+      }
+
+      const summary = [
+        `${data?.matched ?? data?.fetched ?? 0} matched`,
+        `${data?.created ?? 0} created`,
+        `${data?.updated ?? 0} updated`,
+        `${data?.unchanged ?? 0} unchanged`,
+      ].join(", ");
+
+      setCommunitySyncFeedback({
+        tone: "success",
+        text: `${data?.msg || "Community feed sync completed."} ${summary}.`,
+      });
+
+      try {
+        router.refresh();
+      } catch {
+        window.location.reload();
+      }
+    } catch (syncError: unknown) {
+      const message =
+        syncError instanceof Error ? syncError.message : "Unexpected error";
+      setCommunitySyncFeedback({
+        tone: "error",
+        text: message,
+      });
+    } finally {
+      setSyncingCommunity(false);
+    }
+  };
+
+  const handleResetAndResyncCommunity = async () => {
+    if (
+      !window.confirm(
+        "Delete only community-feed events and resync from community feeds? Manually posted and other-source events will be kept.",
+      )
+    ) {
+      return;
+    }
+
+    setError(null);
+    setCommunitySyncFeedback(null);
+    setResettingAndSyncingCommunity(true);
+
+    try {
+      const res = await fetch("/api/events/community/reset-sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const payload = await parseApiPayload(res);
+      const data = (payload.json ?? {}) as {
+        deleted?: number;
+        error?: string;
+        msg?: string;
+        fetched?: number;
+        matched?: number;
+        created?: number;
+        updated?: number;
+        unchanged?: number;
+      };
+
+      if (!res.ok) {
+        setCommunitySyncFeedback({
+          tone: "error",
+          text: extractResponseError(
+            res,
+            payload,
+            "Failed to delete and resync community events.",
+          ),
+        });
+        return;
+      }
+
+      if (!payload.json) {
+        setCommunitySyncFeedback({
+          tone: "error",
+          text: "Reset sync endpoint returned an unexpected response format.",
+        });
+        return;
+      }
+
+      const summary = [
+        `${data?.deleted ?? 0} deleted`,
+        `${data?.matched ?? data?.fetched ?? 0} matched`,
+        `${data?.created ?? 0} created`,
+        `${data?.updated ?? 0} updated`,
+        `${data?.unchanged ?? 0} unchanged`,
+      ].join(", ");
+
+      setCommunitySyncFeedback({
+        tone: "success",
+        text: `${data?.msg || "Delete and resync completed."} ${summary}.`,
+      });
+
+      try {
+        router.refresh();
+      } catch {
+        window.location.reload();
+      }
+    } catch (syncError: unknown) {
+      const message =
+        syncError instanceof Error ? syncError.message : "Unexpected error";
+      setCommunitySyncFeedback({
+        tone: "error",
+        text: message,
+      });
+    } finally {
+      setResettingAndSyncingCommunity(false);
+    }
+  };
+
   return (
     <div className="space-y-8">
-      {isAdmin && (
-        <section className="rounded-xl border border-gray-200 dark:border-gray-700 p-6">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            Eventbrite Grabber
-          </h2>
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-            Grab events from Eventbrite (career fairs, networking events, job fairs, etc.)
-            across major US cities. This will sync events to the database.
-          </p>
+      <section className="rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          Community Event Feeds
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          Pull local networking events, meetups, panels, workshops, and industry talks
+          from configured RSS and ICS feeds. This ignores concert-style events.
+        </p>
 
-          <div className="mt-4 flex flex-wrap items-center gap-3">
-            <button
-              disabled={syncingEventbrite}
-              onClick={handleEventbriteSync}
-              className="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-70"
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <button
+            disabled={syncingCommunity || resettingAndSyncingCommunity}
+            onClick={handleCommunitySync}
+            className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {syncingCommunity ? "Syncing..." : "Sync Community Events"}
+          </button>
+
+          <button
+            disabled={syncingCommunity || resettingAndSyncingCommunity}
+            onClick={handleResetAndResyncCommunity}
+            className="rounded bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {resettingAndSyncingCommunity
+              ? "Deleting + Syncing..."
+              : "Delete Community Events + Resync"}
+          </button>
+
+          {communitySyncFeedback && (
+            <p
+              className={`text-sm ${
+                communitySyncFeedback.tone === "error"
+                  ? "text-red-600"
+                  : "text-blue-700 dark:text-blue-300"
+              }`}
             >
-              {syncingEventbrite ? "Grabbing..." : "Grab Eventbrite Events"}
-            </button>
+              {communitySyncFeedback.text}
+            </p>
+          )}
+        </div>
+      </section>
 
-            {syncFeedback && (
-              <p
-                className={`text-sm ${
-                  syncFeedback.tone === "error"
-                    ? "text-red-600"
-                    : "text-emerald-700 dark:text-emerald-300"
-                }`}
-              >
-                {syncFeedback.text}
-              </p>
-            )}
-          </div>
-        </section>
-      )}
+      <section className="rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          Eventbrite Grabber
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          Grab events from Eventbrite (career fairs, networking events, job fairs, etc.)
+          across major US cities. This will sync events to the database.
+        </p>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <button
+            disabled={syncingEventbrite || resettingAndSyncingEventbrite}
+            onClick={() => void handleEventbriteSync()}
+            className="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {syncingEventbrite ? "Grabbing All Chunks..." : "Grab Eventbrite Events"}
+          </button>
+
+          <button
+            disabled={syncingEventbrite || resettingAndSyncingEventbrite}
+            onClick={() => void handleResetAndResyncEventbrite()}
+            className="rounded bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {resettingAndSyncingEventbrite
+              ? "Deleting + Syncing..."
+              : "Delete Eventbrite Events + Resync"}
+          </button>
+
+          {syncFeedback && (
+            <p
+              className={`text-sm ${
+                syncFeedback.tone === "error"
+                  ? "text-red-600"
+                  : "text-emerald-700 dark:text-emerald-300"
+              }`}
+            >
+              {syncFeedback.text}
+            </p>
+          )}
+        </div>
+      </section>
 
       <section className="rounded-xl border border-gray-200 dark:border-gray-700 p-6">
         <h2 className="text-xl font-semibold text-gray-900 dark:text-white">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -54,7 +54,9 @@ export default async function EventDetailsPage({ params }: PageProps) {
 
           <div className="text-gray-700 dark:text-gray-200 leading-relaxed space-y-3">
             <p>{event.description}</p>
-            <p>{event.details}</p>
+            {event.details && event.details.trim() !== event.description.trim() ? (
+              <p>{event.details}</p>
+            ) : null}
           </div>
 
           <div className="grid gap-4 sm:grid-cols-2">

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -84,13 +84,14 @@ export default async function EventsPage() {
             </div>
           )}
 
-          <section className="mt-10 rounded-lg border border-blue-100 bg-blue-50/60 p-5 text-sm text-blue-900 dark:border-blue-800/50 dark:bg-blue-900/20 dark:text-blue-200">
-            If users want to post events to InternsNow, they can by{" "}
-            <Link href="/events/manage" className="font-semibold underline">
-              clicking here
+          <div className="mt-10 flex justify-center">
+            <Link
+              href="/events/manage"
+              className="inline-flex items-center rounded-lg bg-green-600 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+            >
+              Manage &amp; Sync Events
             </Link>
-            .
-          </section>
+          </div>
         </div>
       </main>
 

--- a/app/lib/integrations/communityFeedSync.ts
+++ b/app/lib/integrations/communityFeedSync.ts
@@ -1,0 +1,292 @@
+import { randomUUID } from "crypto";
+import { revalidatePath } from "next/cache";
+import pool from "../db";
+import {
+  fetchCommunityFeedEvents,
+  formatEventDate,
+  formatEventTime,
+  getCommunityExcludedKeywords,
+  getCommunityKeywords,
+  getCommunityLocations,
+  getConfiguredCommunityFeedConfigs,
+  parseCommunityFeedConfigs,
+  type CommunityFeedEvent,
+} from "./communityFeeds";
+
+export type CommunityFeedSyncRequest = {
+  feedsText?: string;
+  keywordsText?: string;
+  excludeKeywordsText?: string;
+  locationsText?: string;
+};
+
+export type CommunityFeedSourceResult = {
+  label: string;
+  url: string;
+  fetched: number;
+  matched: number;
+  created: number;
+  updated: number;
+  unchanged: number;
+  error?: string;
+};
+
+export type CommunityFeedSyncTotals = {
+  fetched: number;
+  matched: number;
+  created: number;
+  updated: number;
+  unchanged: number;
+};
+
+export type CommunityFeedSyncResult = {
+  ok: boolean;
+  message: string;
+  feeds: CommunityFeedSourceResult[];
+  keywords: string[];
+  locations: string[];
+  totals: CommunityFeedSyncTotals;
+  status: number;
+};
+
+async function ensureSourceColumns() {
+  await pool.query(`
+    ALTER TABLE events
+      ADD COLUMN IF NOT EXISTS source TEXT DEFAULT 'manual',
+      ADD COLUMN IF NOT EXISTS external_id TEXT
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_events_source ON events (source)
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_events_external_id ON events (external_id)
+  `);
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Unknown community feed sync error";
+}
+
+async function upsertCommunityFeedEvent(
+  event: CommunityFeedEvent,
+): Promise<"created" | "updated" | "unchanged"> {
+  const existing = await pool.query(
+    `SELECT id, updated_at FROM events WHERE external_id = $1 AND source = 'community-feed'`,
+    [event.externalId],
+  );
+
+  const tags = Array.from(
+    new Set(["community", "networking", ...event.keywordsMatched].slice(0, 15)),
+  );
+
+  const date = formatEventDate(event.startDate);
+  const time = formatEventTime(event.startDate, event.endDate, event.allDay);
+  const description = event.description || event.title;
+  const details = event.details || description;
+  const location = event.location || event.feedLabel;
+
+  if (existing.rows.length === 0) {
+    const newId = `evt-${randomUUID()}`;
+    await pool.query(
+      `
+      INSERT INTO events (
+        id,
+        title,
+        date,
+        time,
+        location,
+        description,
+        details,
+        host,
+        price,
+        registration_link,
+        tags,
+        source,
+        external_id,
+        created_by,
+        created_by_email
+      ) VALUES (
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'community-feed', $12, 'community-feed-sync', 'community@internsnow.app'
+      )
+      `,
+      [
+        newId,
+        event.title,
+        date,
+        time,
+        location,
+        description,
+        details,
+        event.host,
+        "See website",
+        event.registrationLink,
+        tags,
+        event.externalId,
+      ],
+    );
+    return "created";
+  }
+
+  const previous = existing.rows[0];
+  const currentUpdated = new Date(previous.updated_at).getTime();
+  if (Date.now() - currentUpdated < 60000) {
+    return "unchanged";
+  }
+
+  await pool.query(
+    `
+    UPDATE events SET
+      title = $2,
+      date = $3,
+      time = $4,
+      location = $5,
+      description = $6,
+      details = $7,
+      host = $8,
+      price = $9,
+      registration_link = $10,
+      tags = $11,
+      updated_at = NOW()
+    WHERE external_id = $1 AND source = 'community-feed'
+    `,
+    [
+      event.externalId,
+      event.title,
+      date,
+      time,
+      location,
+      description,
+      details,
+      event.host,
+      "See website",
+      event.registrationLink,
+      tags,
+    ],
+  );
+
+  return "updated";
+}
+
+export async function runCommunityFeedSync(
+  request: CommunityFeedSyncRequest = {},
+): Promise<CommunityFeedSyncResult> {
+  try {
+    await ensureSourceColumns();
+  } catch (error) {
+    return {
+      ok: false,
+      message: "Failed to ensure database schema",
+      feeds: [],
+      keywords: [],
+      locations: [],
+      totals: { fetched: 0, matched: 0, created: 0, updated: 0, unchanged: 0 },
+      status: 500,
+    };
+  }
+
+  const feeds =
+    typeof request.feedsText === "string" && request.feedsText.trim()
+      ? parseCommunityFeedConfigs(request.feedsText)
+      : getConfiguredCommunityFeedConfigs();
+
+  if (feeds.length === 0) {
+    return {
+      ok: false,
+      message:
+        "No community event feeds configured. Add COMMUNITY_EVENT_FEEDS with RSS, ICS, or supported HTML calendar URLs.",
+      feeds: [],
+      keywords: [],
+      locations: [],
+      totals: { fetched: 0, matched: 0, created: 0, updated: 0, unchanged: 0 },
+      status: 400,
+    };
+  }
+
+  const keywords = getCommunityKeywords(
+    request.keywordsText ?? process.env.COMMUNITY_EVENT_KEYWORDS,
+  );
+  const excludedKeywords = getCommunityExcludedKeywords(
+    request.excludeKeywordsText ?? process.env.COMMUNITY_EVENT_EXCLUDE_KEYWORDS,
+  );
+  const locations = getCommunityLocations(request.locationsText ?? process.env.COMMUNITY_EVENT_LOCATIONS);
+
+  const feedResults: CommunityFeedSourceResult[] = [];
+
+  for (const feed of feeds) {
+    const feedResult: CommunityFeedSourceResult = {
+      label: feed.label,
+      url: feed.url,
+      fetched: 0,
+      matched: 0,
+      created: 0,
+      updated: 0,
+      unchanged: 0,
+    };
+
+    try {
+      const events = await fetchCommunityFeedEvents(feed, {
+        keywords,
+        excludedKeywords,
+        locations,
+      });
+
+      feedResult.fetched = events.length;
+      feedResult.matched = events.length;
+
+      for (const event of events) {
+        const result = await upsertCommunityFeedEvent(event);
+
+        if (result === "created") {
+          feedResult.created += 1;
+        } else if (result === "updated") {
+          feedResult.updated += 1;
+        } else {
+          feedResult.unchanged += 1;
+        }
+      }
+    } catch (error) {
+      feedResults.push({
+        ...feedResult,
+        error: getErrorMessage(error),
+      });
+      continue;
+    }
+
+    feedResults.push(feedResult);
+  }
+
+  const totals = feedResults.reduce<CommunityFeedSyncTotals>(
+    (summary, feed) => ({
+      fetched: summary.fetched + feed.fetched,
+      matched: summary.matched + feed.matched,
+      created: summary.created + feed.created,
+      updated: summary.updated + feed.updated,
+      unchanged: summary.unchanged + feed.unchanged,
+    }),
+    { fetched: 0, matched: 0, created: 0, updated: 0, unchanged: 0 },
+  );
+
+  const hasSuccess = feedResults.some((feed) => !feed.error);
+  if (hasSuccess) {
+    revalidatePath("/events");
+    revalidatePath("/student/events");
+  }
+
+  return {
+    ok: hasSuccess,
+    message: hasSuccess
+      ? "Community event feed sync completed"
+      : "Community event feed sync failed",
+    feeds: feedResults,
+    keywords,
+    locations,
+    totals,
+    status: hasSuccess ? 200 : 502,
+  };
+}

--- a/app/lib/integrations/communityFeeds.ts
+++ b/app/lib/integrations/communityFeeds.ts
@@ -1,0 +1,965 @@
+import Parser from "rss-parser";
+
+export type CommunityFeedConfig = {
+  url: string;
+  label: string;
+};
+
+export type CommunityFeedEvent = {
+  externalId: string;
+  title: string;
+  startDate: Date | null;
+  endDate: Date | null;
+  allDay: boolean;
+  location: string;
+  description: string;
+  details: string;
+  host: string;
+  registrationLink: string;
+  feedLabel: string;
+  keywordsMatched: string[];
+};
+
+type RssFeedItem = {
+  title?: string;
+  link?: string;
+  guid?: string;
+  id?: string;
+  isoDate?: string;
+  pubDate?: string;
+  content?: string;
+  contentSnippet?: string;
+  summary?: string;
+  categories?: string[];
+};
+
+type JsonRecord = Record<string, unknown>;
+
+const DEFAULT_COMMUNITY_KEYWORDS = [
+  "networking",
+  "meetup",
+  "tech talk",
+  "industry talk",
+  "speaker",
+  "panel",
+  "fireside",
+  "founder",
+  "startup",
+  "entrepreneur",
+  "professional development",
+  "career",
+  "workshop",
+  "webinar",
+  "innovation",
+  "engineering",
+  "product",
+  "design",
+  "data",
+  "ai",
+  "cybersecurity",
+];
+
+const DEFAULT_EXCLUDED_KEYWORDS = [
+  "concert",
+  "music",
+  "festival",
+  "nightlife",
+  "party",
+  "club",
+  "tour",
+  "comedy",
+  "wrestling",
+  "sports",
+  "opera",
+  "ballet",
+];
+
+const rssParser = new Parser<Record<string, never>, RssFeedItem>({
+  timeout: 15000,
+  headers: {
+    "User-Agent": "InternsNow/1.0 (+https://internsnow.app)",
+    Accept: "application/rss+xml, application/atom+xml, application/xml, text/xml",
+  },
+});
+
+function splitConfigValues(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(/[;\n]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function normalizeText(value: string | null | undefined, limit = 5000): string {
+  if (!value) {
+    return "";
+  }
+
+  return value
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+}
+
+function uniqueLowercase(values: string[]): string[] {
+  return Array.from(
+    new Set(values.map((value) => value.trim().toLowerCase()).filter(Boolean)),
+  );
+}
+
+function safeUrl(value: string): string | null {
+  try {
+    return new URL(value).toString();
+  } catch {
+    return null;
+  }
+}
+
+function toAbsoluteUrl(value: string | null | undefined, baseUrl: string): string | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new URL(value, baseUrl).toString();
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function dedupeCommunityEvents(events: CommunityFeedEvent[]): CommunityFeedEvent[] {
+  const seen = new Set<string>();
+
+  return events.filter((event) => {
+    if (seen.has(event.externalId)) {
+      return false;
+    }
+
+    seen.add(event.externalId);
+    return true;
+  });
+}
+
+function parseFeedConfigEntry(entry: string): CommunityFeedConfig | null {
+  const [rawUrl, rawLabel] = entry.split("|");
+  const url = safeUrl(rawUrl?.trim() ?? "");
+
+  if (!url) {
+    return null;
+  }
+
+  return {
+    url,
+    label: rawLabel?.trim() || new URL(url).hostname,
+  };
+}
+
+export function parseCommunityFeedConfigs(raw?: string): CommunityFeedConfig[] {
+  const feeds = splitConfigValues(raw)
+    .map(parseFeedConfigEntry)
+    .filter((feed): feed is CommunityFeedConfig => Boolean(feed));
+
+  const seenUrls = new Set<string>();
+  return feeds.filter((feed) => {
+    if (seenUrls.has(feed.url)) {
+      return false;
+    }
+    seenUrls.add(feed.url);
+    return true;
+  });
+}
+
+export function getConfiguredCommunityFeedConfigs(): CommunityFeedConfig[] {
+  return parseCommunityFeedConfigs(process.env.COMMUNITY_EVENT_FEEDS);
+}
+
+export function getCommunityKeywords(raw?: string): string[] {
+  const configured = uniqueLowercase(splitConfigValues(raw));
+  return configured.length > 0 ? configured : DEFAULT_COMMUNITY_KEYWORDS;
+}
+
+export function getCommunityExcludedKeywords(raw?: string): string[] {
+  const configured = uniqueLowercase(splitConfigValues(raw));
+  return configured.length > 0 ? configured : DEFAULT_EXCLUDED_KEYWORDS;
+}
+
+export function getCommunityLocations(raw?: string): string[] {
+  return uniqueLowercase(splitConfigValues(raw));
+}
+
+function parseDate(value: string | Date | null | undefined): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function keywordToRegex(keyword: string): RegExp {
+  const normalized = keyword.trim().toLowerCase();
+  const pattern = normalized
+    .split(/\s+/)
+    .map((part) => escapeRegex(part))
+    .join("\\s+");
+
+  return new RegExp(`(^|[^a-z0-9])${pattern}([^a-z0-9]|$)`, "i");
+}
+
+function includesKeyword(haystack: string, keyword: string): boolean {
+  return keywordToRegex(keyword).test(haystack);
+}
+
+function collectMatchedKeywords(haystack: string, keywords: string[]): string[] {
+  return keywords.filter((keyword) => includesKeyword(haystack, keyword));
+}
+
+function isFutureEvent(date: Date | null): boolean {
+  if (!date) {
+    return true;
+  }
+
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 1);
+  return date >= cutoff;
+}
+
+function buildHaystack(parts: Array<string | string[] | null | undefined>): string {
+  return parts
+    .flatMap((part) => (Array.isArray(part) ? part : [part]))
+    .map((part) => normalizeText(part ?? "", 1000).toLowerCase())
+    .filter(Boolean)
+    .join(" ");
+}
+
+function matchesLocation(haystack: string, locations: string[]): boolean {
+  if (locations.length === 0) {
+    return true;
+  }
+
+  return locations.some((location) => includesKeyword(haystack, location));
+}
+
+function shouldIncludeEvent(input: {
+  haystack: string;
+  locations: string[];
+  keywords: string[];
+  excludedKeywords: string[];
+  startDate: Date | null;
+}): { include: boolean; matchedKeywords: string[] } {
+  if (!isFutureEvent(input.startDate)) {
+    return { include: false, matchedKeywords: [] };
+  }
+
+  const matchedKeywords = collectMatchedKeywords(input.haystack, input.keywords);
+  if (matchedKeywords.length === 0) {
+    return { include: false, matchedKeywords: [] };
+  }
+
+  const hasExcludedKeyword = input.excludedKeywords.some((keyword) =>
+    includesKeyword(input.haystack, keyword),
+  );
+  if (hasExcludedKeyword) {
+    return { include: false, matchedKeywords: [] };
+  }
+
+  if (!matchesLocation(input.haystack, input.locations)) {
+    return { include: false, matchedKeywords: [] };
+  }
+
+  return { include: true, matchedKeywords };
+}
+
+function createFallbackExternalId(feedUrl: string, title: string, date: string): string {
+  const slug = `${title}|${date}`.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  return `${feedUrl}::${slug}`;
+}
+
+function parseRssItem(
+  feed: CommunityFeedConfig,
+  item: RssFeedItem,
+  options: {
+    keywords: string[];
+    excludedKeywords: string[];
+    locations: string[];
+  },
+): CommunityFeedEvent | null {
+  const title = normalizeText(item.title, 250);
+  if (!title) {
+    return null;
+  }
+
+  const description = normalizeText(
+    item.contentSnippet || item.summary || item.content,
+    1200,
+  );
+  const details = normalizeText(item.content || item.summary || item.contentSnippet);
+  const startDate = parseDate(item.isoDate || item.pubDate);
+  const categories = Array.isArray(item.categories) ? item.categories : [];
+  const registrationLink = safeUrl(item.link || "") ?? feed.url;
+  const haystack = buildHaystack([
+    title,
+    description,
+    details,
+    categories,
+    feed.label,
+  ]);
+
+  const decision = shouldIncludeEvent({
+    haystack,
+    locations: options.locations,
+    keywords: options.keywords,
+    excludedKeywords: options.excludedKeywords,
+    startDate,
+  });
+
+  if (!decision.include) {
+    return null;
+  }
+
+  const externalId =
+    item.guid || item.id || createFallbackExternalId(feed.url, title, startDate?.toISOString() || "unknown");
+
+  return {
+    externalId,
+    title,
+    startDate,
+    endDate: null,
+    allDay: false,
+    location: "",
+    description,
+    details,
+    host: feed.label,
+    registrationLink,
+    feedLabel: feed.label,
+    keywordsMatched: decision.matchedKeywords,
+  };
+}
+
+function parseIcsEvent(
+  feed: CommunityFeedConfig,
+  event: Record<string, unknown>,
+  options: {
+    keywords: string[];
+    excludedKeywords: string[];
+    locations: string[];
+  },
+): CommunityFeedEvent | null {
+  const title = normalizeText(typeof event.summary === "string" ? event.summary : "", 250);
+  if (!title) {
+    return null;
+  }
+
+  const description = normalizeText(
+    typeof event.description === "string" ? event.description : "",
+    1200,
+  );
+  const details = normalizeText(typeof event.description === "string" ? event.description : "");
+  const location = normalizeText(typeof event.location === "string" ? event.location : "", 300);
+  const startDate = parseDate(event.start as string | Date | null | undefined);
+  const endDate = parseDate(event.end as string | Date | null | undefined);
+  const urlField =
+    typeof event.url === "string"
+      ? event.url
+      : typeof event.url === "object" && event.url && "val" in event.url
+        ? String((event.url as { val?: unknown }).val ?? "")
+        : "";
+  const registrationLink = safeUrl(urlField) ?? feed.url;
+  const haystack = buildHaystack([title, description, details, location, feed.label]);
+
+  const decision = shouldIncludeEvent({
+    haystack,
+    locations: options.locations,
+    keywords: options.keywords,
+    excludedKeywords: options.excludedKeywords,
+    startDate,
+  });
+
+  if (!decision.include) {
+    return null;
+  }
+
+  const uid = typeof event.uid === "string" ? event.uid : createFallbackExternalId(feed.url, title, startDate?.toISOString() || "unknown");
+  const datetype = typeof event.datetype === "string" ? event.datetype : "";
+
+  return {
+    externalId: `${feed.url}::${uid}`,
+    title,
+    startDate,
+    endDate,
+    allDay: datetype === "date",
+    location,
+    description,
+    details,
+    host: feed.label,
+    registrationLink,
+    feedLabel: feed.label,
+    keywordsMatched: decision.matchedKeywords,
+  };
+}
+
+function buildPatchLocation(address: unknown): string {
+  if (typeof address === "string") {
+    return normalizeText(address, 300);
+  }
+
+  if (!isRecord(address)) {
+    return "";
+  }
+
+  return normalizeText(
+    [
+      typeof address.name === "string" ? address.name : "",
+      typeof address.streetAddress === "string" ? address.streetAddress : "",
+      typeof address.city === "string" ? address.city : "",
+      typeof address.region === "string" ? address.region : "",
+      typeof address.postalCode === "string" ? address.postalCode : "",
+    ]
+      .filter(Boolean)
+      .join(", "),
+    300,
+  );
+}
+
+function parsePatchEvent(
+  feed: CommunityFeedConfig,
+  event: JsonRecord,
+  options: {
+    keywords: string[];
+    excludedKeywords: string[];
+    locations: string[];
+  },
+): CommunityFeedEvent | null {
+  const title = normalizeText(typeof event.title === "string" ? event.title : "", 250);
+  if (!title) {
+    return null;
+  }
+
+  const description = normalizeText(
+    typeof event.summary === "string" ? event.summary : typeof event.body === "string" ? event.body : "",
+    1200,
+  );
+  const details = normalizeText(
+    typeof event.body === "string" ? event.body : typeof event.summary === "string" ? event.summary : "",
+  );
+  const location = buildPatchLocation(event.address);
+  const startDate = parseDate(
+    typeof event.displayDate === "string"
+      ? event.displayDate
+      : typeof event.startDate === "string"
+        ? event.startDate
+        : null,
+  );
+  const host =
+    isRecord(event.patch) && typeof event.patch.name === "string"
+      ? normalizeText(event.patch.name, 120)
+      : feed.label;
+  const registrationLink =
+    safeUrl(typeof event.eventSiteUrl === "string" ? event.eventSiteUrl : "") ??
+    toAbsoluteUrl(
+      typeof event.canonicalUrl === "string"
+        ? event.canonicalUrl
+        : typeof event.itemAlias === "string"
+          ? event.itemAlias
+          : null,
+      feed.url,
+    ) ??
+    feed.url;
+  const haystack = buildHaystack([
+    title,
+    description,
+    details,
+    location,
+    host,
+    feed.label,
+    typeof event.eventType === "string" ? event.eventType : "",
+  ]);
+
+  const decision = shouldIncludeEvent({
+    haystack,
+    locations: options.locations,
+    keywords: options.keywords,
+    excludedKeywords: options.excludedKeywords,
+    startDate,
+  });
+
+  if (!decision.include) {
+    return null;
+  }
+
+  const rawId =
+    typeof event.id === "string" || typeof event.id === "number"
+      ? String(event.id)
+      : typeof event.itemAlias === "string"
+        ? event.itemAlias
+        : createFallbackExternalId(feed.url, title, startDate?.toISOString() || "unknown");
+
+  return {
+    externalId: `${feed.url}::patch::${rawId}`,
+    title,
+    startDate,
+    endDate: null,
+    allDay: false,
+    location,
+    description,
+    details,
+    host,
+    registrationLink,
+    feedLabel: feed.label,
+    keywordsMatched: decision.matchedKeywords,
+  };
+}
+
+function collectPatchEventObjects(value: unknown, matches: JsonRecord[]): void {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectPatchEventObjects(item, matches));
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  const looksLikePatchEvent =
+    value.type === "event" &&
+    typeof value.title === "string" &&
+    (typeof value.displayDate === "string" || typeof value.startDate === "string");
+
+  if (looksLikePatchEvent) {
+    matches.push(value);
+  }
+
+  Object.values(value).forEach((child) => collectPatchEventObjects(child, matches));
+}
+
+function extractNextDataJson(html: string): unknown {
+  const match = html.match(/<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/i);
+  if (!match) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+function extractJsonLdBlocks(html: string): unknown[] {
+  const blocks: unknown[] = [];
+  const regex = /<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi;
+
+  for (const match of html.matchAll(regex)) {
+    const raw = match[1]?.trim();
+    if (!raw) {
+      continue;
+    }
+
+    try {
+      blocks.push(JSON.parse(raw));
+    } catch {
+      continue;
+    }
+  }
+
+  return blocks;
+}
+
+function collectJsonLdEventObjects(value: unknown, matches: JsonRecord[]): void {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectJsonLdEventObjects(item, matches));
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  const rawType = value["@type"];
+  const types = Array.isArray(rawType)
+    ? rawType.filter((item): item is string => typeof item === "string")
+    : typeof rawType === "string"
+      ? [rawType]
+      : [];
+
+  if (types.includes("Event")) {
+    matches.push(value);
+  }
+
+  Object.values(value).forEach((child) => collectJsonLdEventObjects(child, matches));
+}
+
+function parseJsonLdEvent(
+  feed: CommunityFeedConfig,
+  event: JsonRecord,
+  options: {
+    keywords: string[];
+    excludedKeywords: string[];
+    locations: string[];
+  },
+): CommunityFeedEvent | null {
+  const title = normalizeText(typeof event.name === "string" ? event.name : "", 250);
+  if (!title) {
+    return null;
+  }
+
+  const description = normalizeText(typeof event.description === "string" ? event.description : "", 1200);
+  const location = isRecord(event.location)
+    ? normalizeText(
+        [
+          typeof event.location.name === "string" ? event.location.name : "",
+          isRecord(event.location.address) && typeof event.location.address.addressLocality === "string"
+            ? event.location.address.addressLocality
+            : "",
+          isRecord(event.location.address) && typeof event.location.address.addressRegion === "string"
+            ? event.location.address.addressRegion
+            : "",
+        ]
+          .filter(Boolean)
+          .join(", "),
+        300,
+      )
+    : "";
+  const startDate = parseDate(typeof event.startDate === "string" ? event.startDate : null);
+  const endDate = parseDate(typeof event.endDate === "string" ? event.endDate : null);
+  const registrationLink =
+    safeUrl(typeof event.url === "string" ? event.url : "") ??
+    safeUrl(typeof event.sameAs === "string" ? event.sameAs : "") ??
+    feed.url;
+  const haystack = buildHaystack([title, description, location, feed.label]);
+
+  const decision = shouldIncludeEvent({
+    haystack,
+    locations: options.locations,
+    keywords: options.keywords,
+    excludedKeywords: options.excludedKeywords,
+    startDate,
+  });
+
+  if (!decision.include) {
+    return null;
+  }
+
+  const rawId =
+    typeof event["@id"] === "string"
+      ? event["@id"]
+      : typeof event.url === "string"
+        ? event.url
+        : createFallbackExternalId(feed.url, title, startDate?.toISOString() || "unknown");
+
+  return {
+    externalId: `${feed.url}::jsonld::${rawId}`,
+    title,
+    startDate,
+    endDate,
+    allDay: false,
+    location,
+    description,
+    details: description,
+    host: feed.label,
+    registrationLink,
+    feedLabel: feed.label,
+    keywordsMatched: decision.matchedKeywords,
+  };
+}
+
+function extractLiveWhaleEvents(html: string): JsonRecord[] {
+  const match = html.match(/var\s+livewhale\s*=\s*(\{[\s\S]+?\});\s*\n/);
+  if (!match) {
+    return [];
+  }
+
+  try {
+    const lw = JSON.parse(match[1].replace(/\\\//g, "/")) as unknown;
+    if (!isRecord(lw)) {
+      return [];
+    }
+
+    const calendar = lw.calendar;
+    if (!isRecord(calendar)) {
+      return [];
+    }
+
+    const preload = calendar.preload_data;
+    if (!isRecord(preload)) {
+      return [];
+    }
+
+    const events = preload.events;
+    if (!Array.isArray(events)) {
+      return [];
+    }
+
+    return events.filter(isRecord);
+  } catch {
+    return [];
+  }
+}
+
+function parseLiveWhaleEvent(
+  feed: CommunityFeedConfig,
+  event: JsonRecord,
+  options: {
+    keywords: string[];
+    excludedKeywords: string[];
+    locations: string[];
+  },
+): CommunityFeedEvent | null {
+  const title = normalizeText(typeof event.title === "string" ? event.title : "", 250);
+  if (!title) {
+    return null;
+  }
+
+  if (event.is_canceled === true || event.status === "0") {
+    return null;
+  }
+
+  const summary = normalizeText(typeof event.summary === "string" ? event.summary : "", 1200);
+  const location = normalizeText(typeof event.location === "string" ? event.location : "", 300);
+  const categories = Array.isArray(event.categories)
+    ? (event.categories as unknown[]).filter((c): c is string => typeof c === "string")
+    : [];
+  const categoriesAudience = Array.isArray(event.categories_audience)
+    ? (event.categories_audience as unknown[]).filter((c): c is string => typeof c === "string")
+    : [];
+  const tags = Array.isArray(event.tags)
+    ? (event.tags as unknown[]).filter((t): t is string => typeof t === "string")
+    : [];
+
+  const tsStart = typeof event.ts_start === "number" ? event.ts_start : null;
+  const tsEnd = typeof event.ts_end === "number" ? event.ts_end : null;
+  const startDate = tsStart !== null ? new Date(tsStart * 1000) : null;
+  const endDate = tsEnd !== null ? new Date(tsEnd * 1000) : null;
+
+  const href = typeof event.href === "string" ? event.href : null;
+  const registrationLink = toAbsoluteUrl(href, feed.url) ?? feed.url;
+
+  const haystack = buildHaystack([
+    title,
+    summary,
+    location,
+    categories,
+    categoriesAudience,
+    tags,
+    feed.label,
+  ]);
+
+  const decision = shouldIncludeEvent({
+    haystack,
+    locations: options.locations,
+    keywords: options.keywords,
+    excludedKeywords: options.excludedKeywords,
+    startDate,
+  });
+
+  if (!decision.include) {
+    return null;
+  }
+
+  const rawId = typeof event.id === "string" || typeof event.id === "number"
+    ? String(event.id)
+    : createFallbackExternalId(feed.url, title, startDate?.toISOString() || "unknown");
+
+  return {
+    externalId: `${feed.url}::lw::${rawId}`,
+    title,
+    startDate,
+    endDate,
+    allDay: event.is_all_day === true,
+    location,
+    description: summary,
+    details: summary,
+    host: feed.label,
+    registrationLink,
+    feedLabel: feed.label,
+    keywordsMatched: decision.matchedKeywords,
+  };
+}
+
+function parseHtmlFeedEvents(
+  feed: CommunityFeedConfig,
+  html: string,
+  options: {
+    keywords: string[];
+    excludedKeywords: string[];
+    locations: string[];
+  },
+): { events: CommunityFeedEvent[]; discoveredCount: number } {
+  // LiveWhale (UConn-style) embedded events
+  const liveWhaleObjects = extractLiveWhaleEvents(html);
+  const liveWhaleEvents = liveWhaleObjects
+    .map((event) => parseLiveWhaleEvent(feed, event, options))
+    .filter((event): event is CommunityFeedEvent => Boolean(event));
+
+  // Patch-style __NEXT_DATA__ events
+  const nextData = extractNextDataJson(html);
+  const patchEventObjects: JsonRecord[] = [];
+  collectPatchEventObjects(nextData, patchEventObjects);
+
+  const patchEvents = patchEventObjects
+    .map((event) => parsePatchEvent(feed, event, options))
+    .filter((event): event is CommunityFeedEvent => Boolean(event));
+
+  const jsonLdEventObjects = extractJsonLdBlocks(html).flatMap((block) => {
+    const matches: JsonRecord[] = [];
+    collectJsonLdEventObjects(block, matches);
+    return matches;
+  });
+
+  const jsonLdEvents = jsonLdEventObjects
+    .map((event) => parseJsonLdEvent(feed, event, options))
+    .filter((event): event is CommunityFeedEvent => Boolean(event));
+
+  const discoveredCount = liveWhaleObjects.length + patchEventObjects.length + jsonLdEventObjects.length;
+
+  return {
+    events: dedupeCommunityEvents([...liveWhaleEvents, ...patchEvents, ...jsonLdEvents]),
+    discoveredCount,
+  };
+}
+
+export async function fetchCommunityFeedEvents(
+  feed: CommunityFeedConfig,
+  options: {
+    keywords: string[];
+    excludedKeywords: string[];
+    locations: string[];
+  },
+): Promise<CommunityFeedEvent[]> {
+  const response = await fetch(feed.url, {
+    headers: {
+      "User-Agent": "InternsNow/1.0 (+https://internsnow.app)",
+      Accept: "text/calendar, application/rss+xml, application/atom+xml, application/xml, text/xml, text/html",
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Feed request failed (${response.status})`);
+  }
+
+  const text = await response.text();
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  const looksLikeIcs =
+    feed.url.toLowerCase().endsWith(".ics") ||
+    contentType.includes("text/calendar") ||
+    text.includes("BEGIN:VCALENDAR");
+  const looksLikeHtml =
+    contentType.includes("text/html") ||
+    /<html[\s>]/i.test(text) ||
+    text.includes("__NEXT_DATA__");
+
+  if (looksLikeIcs) {
+    let parsed: Record<string, unknown>;
+    try {
+      const icalModule = await import("node-ical");
+      parsed = icalModule.parseICS(text) as Record<string, unknown>;
+    } catch (error) {
+      throw new Error(
+        `Failed to parse ICS feed: ${error instanceof Error ? error.message : "Unknown ICS parse error"}`,
+      );
+    }
+
+    const events: CommunityFeedEvent[] = [];
+
+    for (const entry of Object.values(parsed)) {
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+
+      if (!("type" in entry) || entry.type !== "VEVENT") {
+        continue;
+      }
+
+      if ("status" in entry && entry.status === "CANCELLED") {
+        continue;
+      }
+
+      const event = parseIcsEvent(feed, entry as Record<string, unknown>, options);
+      if (event) {
+        events.push(event);
+      }
+    }
+
+    return events;
+  }
+
+  if (looksLikeHtml) {
+    const htmlResult = parseHtmlFeedEvents(feed, text, options);
+    if (htmlResult.discoveredCount > 0) {
+      return htmlResult.events;
+    }
+  }
+
+  try {
+    const parsed = await rssParser.parseString(text);
+    return (parsed.items ?? [])
+      .map((item) => parseRssItem(feed, item, options))
+      .filter((event): event is CommunityFeedEvent => Boolean(event));
+  } catch (error) {
+    if (looksLikeHtml) {
+      throw new Error(`HTML calendar page did not expose any supported event data: ${error instanceof Error ? error.message : "Unknown parse error"}`);
+    }
+
+    throw error;
+  }
+}
+
+export function formatEventDate(date: Date | null): string {
+  if (!date) {
+    return "TBD";
+  }
+
+  return date.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatClockTime(date: Date): string {
+  return date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+export function formatEventTime(
+  startDate: Date | null,
+  endDate: Date | null,
+  allDay: boolean,
+): string {
+  if (!startDate) {
+    return "TBD";
+  }
+
+  if (allDay) {
+    return "All day";
+  }
+
+  const start = formatClockTime(startDate);
+  if (!endDate) {
+    return start;
+  }
+
+  return `${start} - ${formatClockTime(endDate)}`;
+}

--- a/app/lib/integrations/eventPrune.ts
+++ b/app/lib/integrations/eventPrune.ts
@@ -1,0 +1,141 @@
+import pool from "@/app/lib/db";
+
+type MinimalEventRow = {
+  id: string;
+  date: string;
+  time: string;
+};
+
+export type EventPruneResult = {
+  scanned: number;
+  pruned: number;
+  skippedUnparseable: number;
+};
+
+function cleanDateText(value: string): string {
+  return value
+    .replace(/\s*\+\s*\d+\s+more.*/i, "")
+    .replace(/\s*•\s*/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function hasExplicitYear(value: string): boolean {
+  return /\b\d{4}\b/.test(value);
+}
+
+function parseDateOnly(dateText: string): Date | null {
+  const cleaned = cleanDateText(dateText);
+  if (!cleaned) {
+    return null;
+  }
+
+  // Strings like "Wed, Apr 29, 6:00 PM" are parsed by JS as year 2001.
+  // If year is missing, force current year before parsing.
+  if (hasExplicitYear(cleaned)) {
+    const direct = new Date(cleaned);
+    if (!Number.isNaN(direct.getTime())) {
+      return direct;
+    }
+  }
+
+  // Add current year for strings like "Thu, Apr 30".
+  const withYear = `${cleaned} ${new Date().getFullYear()}`;
+  const withYearParsed = new Date(withYear);
+  if (!Number.isNaN(withYearParsed.getTime())) {
+    return withYearParsed;
+  }
+
+  return null;
+}
+
+function parseTimeOnDate(baseDate: Date, timeText: string): Date | null {
+  const cleaned = cleanDateText(timeText);
+  if (!cleaned) {
+    return null;
+  }
+
+  // If this is a range, use the end time.
+  const endCandidate = cleaned.includes("-")
+    ? cleaned.split("-").pop()?.trim() ?? cleaned
+    : cleaned;
+
+  const datePart = baseDate.toDateString();
+  const combined = new Date(`${datePart} ${endCandidate}`);
+  if (!Number.isNaN(combined.getTime())) {
+    return combined;
+  }
+
+  return null;
+}
+
+function inferEventEnd(dateText: string, timeText: string): Date | null {
+  const parsedDate = parseDateOnly(dateText);
+  if (!parsedDate) {
+    return null;
+  }
+
+  // If date text already includes a specific time, keep it.
+  const dateHasTime = /\b\d{1,2}:\d{2}\s?(AM|PM)\b/i.test(dateText);
+  if (dateHasTime) {
+    return parsedDate;
+  }
+
+  const parsedTime = parseTimeOnDate(parsedDate, timeText);
+  if (parsedTime) {
+    return parsedTime;
+  }
+
+  // Date-only events expire at end of local day.
+  const endOfDay = new Date(parsedDate);
+  endOfDay.setHours(23, 59, 59, 999);
+  return endOfDay;
+}
+
+export async function prunePastEvents(now = new Date()): Promise<EventPruneResult> {
+  const result = await pool.query(
+    `
+      SELECT id, date, time
+      FROM events
+      WHERE deleted_at IS NULL
+    `,
+  );
+
+  const rows = result.rows as MinimalEventRow[];
+
+  const toPrune: string[] = [];
+  let skippedUnparseable = 0;
+
+  for (const row of rows) {
+    const inferredEnd = inferEventEnd(String(row.date ?? ""), String(row.time ?? ""));
+    if (!inferredEnd) {
+      skippedUnparseable += 1;
+      continue;
+    }
+
+    if (inferredEnd.getTime() < now.getTime()) {
+      toPrune.push(row.id);
+    }
+  }
+
+  if (toPrune.length > 0) {
+    await pool.query(
+      `
+        UPDATE events
+        SET
+          deleted_at = NOW(),
+          deleted_by = 'system-prune',
+          updated_at = NOW()
+        WHERE id = ANY($1::text[])
+          AND deleted_at IS NULL
+      `,
+      [toPrune],
+    );
+  }
+
+  return {
+    scanned: rows.length,
+    pruned: toPrune.length,
+    skippedUnparseable,
+  };
+}

--- a/app/lib/integrations/eventbriteGrabber.ts
+++ b/app/lib/integrations/eventbriteGrabber.ts
@@ -9,15 +9,31 @@ export type GrabbedEvent = {
   source: string;
 };
 
-const KEYWORDS = [
+export type EventbriteGrabberRunResult = {
+  events: GrabbedEvent[];
+  attemptedQueries: number;
+  failedQueries: number;
+  totalQueries: number;
+  chunkIndex: number;
+  chunkCount: number;
+};
+
+export type EventbriteGrabberOptions = {
+  chunkIndex?: number;
+  useNextChunk?: boolean;
+  maxQueriesPerRun?: number;
+  timeoutMs?: number;
+};
+
+const DEFAULT_KEYWORDS = [
   "career fair",
-  "tech networking", 
+  "tech networking",
   "job fair",
   "internship",
   "career workshop",
 ];
 
-const US_LOCATIONS = [
+const DEFAULT_LOCATIONS = [
   "New York",
   "Los Angeles",
   "Chicago",
@@ -40,130 +56,472 @@ const US_LOCATIONS = [
   "Portland",
 ];
 
+const DEFAULT_EXCLUDE_KEYWORDS = [
+  "concert",
+  "music",
+  "festival",
+  "nightlife",
+  "club",
+  "comedy",
+  "dating",
+  "singles",
+  "party",
+];
+
+function splitConfigValues(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(/[;\n]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+// Prefer dedicated Eventbrite keyword config; fall back to community keywords.
+function getConfiguredKeywords(): string[] {
+  const configured = unique(
+    splitConfigValues(
+      process.env.EVENTBRITE_GRABBER_KEYWORDS ?? process.env.COMMUNITY_EVENT_KEYWORDS,
+    ),
+  );
+  return configured.length > 0 ? configured : DEFAULT_KEYWORDS;
+}
+
+function getConfiguredLocations(): string[] {
+  const configured = unique(
+    splitConfigValues(
+      process.env.EVENTBRITE_GRABBER_LOCATIONS ?? process.env.COMMUNITY_EVENT_LOCATIONS,
+    ),
+  );
+  return configured.length > 0 ? configured : DEFAULT_LOCATIONS;
+}
+
+function getConfiguredExcludeKeywords(): string[] {
+  const configured = unique(
+    splitConfigValues(
+      process.env.EVENTBRITE_GRABBER_EXCLUDE_KEYWORDS ?? process.env.COMMUNITY_EVENT_EXCLUDE_KEYWORDS,
+    ),
+  );
+  return configured.length > 0 ? configured : DEFAULT_EXCLUDE_KEYWORDS;
+}
+
+function toEventbriteSlug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-");
+}
+
+function getTimeoutMs(override?: number): number {
+  if (Number.isFinite(override) && Number(override) >= 1000) {
+    return Math.floor(Number(override));
+  }
+
+  const raw = Number(process.env.EVENTBRITE_GRABBER_TIMEOUT_MS ?? "12000");
+  if (!Number.isFinite(raw) || raw < 1000) {
+    return 12000;
+  }
+  return Math.floor(raw);
+}
+
+function getMaxQueriesPerRun(totalQueries: number, override?: number): number {
+  if (Number.isFinite(override) && Number(override) > 0) {
+    return Math.max(1, Math.min(Math.floor(Number(override)), totalQueries));
+  }
+
+  const raw = Number(process.env.EVENTBRITE_GRABBER_MAX_QUERIES_PER_RUN ?? "25");
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return Math.min(25, totalQueries);
+  }
+  return Math.max(1, Math.min(Math.floor(raw), totalQueries));
+}
+
+function getChunkIndex(chunkCount: number, override?: number): number {
+  if (Number.isInteger(override) && Number(override) >= 0) {
+    return Number(override) % chunkCount;
+  }
+
+  const explicit = Number(process.env.EVENTBRITE_GRABBER_CHUNK_INDEX);
+  if (Number.isInteger(explicit) && explicit >= 0) {
+    return explicit % chunkCount;
+  }
+
+  // Rotate chunks daily when no explicit index is set.
+  const dayOfYear = Math.floor((Date.now() - Date.UTC(new Date().getUTCFullYear(), 0, 0)) / 86400000);
+  return dayOfYear % chunkCount;
+}
+
+async function fetchWithTimeout(
+  input: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(input, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function extractEventId(url: string): string {
-  const match = url.match(/\/e\/[^"-]+-(\d+)/);
-  return match ? match[1] : url.slice(-15);
+  const match = url.match(/\/e\/[^/?"#]*-(\d+)(?:[?#]|$)/i);
+  if (match) {
+    return match[1];
+  }
+
+  // Last-resort fallback when URL shape changes: keep a deterministic id from the path.
+  const path = url.split("?")[0].split("#")[0];
+  const tail = path.split("/").filter(Boolean).pop() ?? path;
+  return `eb-${tail}`;
 }
 
 function normalizeText(text: string | null | undefined): string {
   if (!text) return "";
-  return text.replace(/<[^>]+>/g, "").replace(/&[^;]+;/g, " ").trim().slice(0, 200);
+  return text
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+function normalizeLocationForMatch(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function locationNeedles(requestedLocation: string): string[] {
+  const normalized = normalizeLocationForMatch(requestedLocation);
+  if (!normalized) {
+    return [];
+  }
+
+  const parts = normalized.split(" ").filter(Boolean);
+  const cityPart = normalizeLocationForMatch(requestedLocation.split(",")[0] ?? requestedLocation);
+
+  const countyNeedles = /fairfield\s+county/i.test(requestedLocation)
+    ? [
+        "stamford",
+        "norwalk",
+        "fairfield",
+        "greenwich",
+        "westport",
+        "darien",
+        "new canaan",
+        "bridgeport",
+        "ct",
+      ]
+    : [];
+
+  return unique([
+    cityPart,
+    normalized,
+    ...countyNeedles,
+    ...parts.filter((p) => p.length >= 4),
+  ]);
+}
+
+function matchesRequestedLocation(eventLocation: string, requestedLocation: string): boolean {
+  const haystack = normalizeLocationForMatch(eventLocation);
+  const needles = locationNeedles(requestedLocation);
+  if (!haystack || needles.length === 0) {
+    return false;
+  }
+
+  return needles.some((needle) => needle.length >= 2 && haystack.includes(needle));
+}
+
+function normalizeForRelevance(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokenizeKeyword(value: string): string[] {
+  const stopWords = new Set(["in", "and", "for", "the", "event", "events", "fair"]);
+  return normalizeForRelevance(value)
+    .split(" ")
+    .filter((token) => token.length >= 4 && !stopWords.has(token));
+}
+
+function matchesKeywordIntent(searchable: string, keyword: string): boolean {
+  const haystack = normalizeForRelevance(searchable);
+  const normalizedKeyword = normalizeForRelevance(keyword);
+
+  if (normalizedKeyword && haystack.includes(normalizedKeyword)) {
+    return true;
+  }
+
+  const tokens = tokenizeKeyword(keyword);
+  if (tokens.length === 0) {
+    return true;
+  }
+
+  const hits = tokens.filter((token) => haystack.includes(token)).length;
+  const requiredHits = tokens.length <= 2 ? 1 : 2;
+  return hits >= requiredHits;
+}
+
+function matchesExcludeKeywords(searchable: string, excludeKeywords: string[]): boolean {
+  const haystack = normalizeForRelevance(searchable);
+  return excludeKeywords.some((keyword) => {
+    const needle = normalizeForRelevance(keyword);
+    return needle.length >= 3 && haystack.includes(needle);
+  });
+}
+
+function buildEventFromCard(
+  cardHtml: string,
+  location: string,
+  keyword: string,
+  excludeKeywords: string[],
+): GrabbedEvent | null {
+  const eventUrlMatch = cardHtml.match(/href="(https:\/\/www\.eventbrite\.com\/e\/[^"?#]+(?:\?[^"#]*)?)"/i);
+  if (!eventUrlMatch) {
+    return null;
+  }
+
+  const eventUrl = eventUrlMatch[1];
+  const eventId = extractEventId(eventUrl);
+
+  const titleMatch = cardHtml.match(/<h3[^>]*>([\s\S]*?)<\/h3>/i);
+  const titleIndex = titleMatch?.index ?? 0;
+  const localContext = cardHtml.slice(Math.max(0, titleIndex - 120), titleIndex + 1400);
+  const pMatches = Array.from(localContext.matchAll(/<p[^>]*>([\s\S]*?)<\/p>/gi));
+
+  const rawTitle = normalizeText(titleMatch?.[1]);
+  const paragraphValues = pMatches
+    .map((m) => normalizeText(m?.[1]))
+    .filter((value) => value.length > 0 && value.length <= 120);
+
+  const looksLikeDateTime = (value: string): boolean =>
+    /\b(mon|tue|wed|thu|fri|sat|sun|today|tomorrow)\b|\b\d{1,2}:\d{2}\s?(am|pm)\b|\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b/i.test(
+      value,
+    );
+  const looksLikeStatus = (value: string): boolean =>
+    /almost full|sold out|few tickets left/i.test(value);
+  const looksLikeLocation = (value: string): boolean =>
+    /·|\blocation\b|\bnew york\b|\bbrooklyn\b|\bmanhattan\b|\bqueens\b|\bbronx\b|\bstaten island\b|\b[a-z]+,\s?[a-z]{2}\b/i.test(
+      value,
+    );
+
+  const rawDateTime =
+    paragraphValues.find((value) => looksLikeDateTime(value) && !looksLikeStatus(value)) ?? "";
+  const rawLocation =
+    paragraphValues.find((value) => !looksLikeStatus(value) && looksLikeLocation(value) && value !== rawDateTime) ?? "";
+
+  // Do not create low-information events.
+  if (!rawTitle || rawTitle.length < 5 || !rawDateTime) {
+    return null;
+  }
+
+  const title = rawTitle;
+  const dateTime = rawDateTime;
+  const eventLocation = rawLocation || location;
+
+  const relevanceText = `${title} ${eventLocation}`;
+
+  // Skip virtual/online events to keep results locally actionable.
+  if (/\bvirtual\b|\bonline\b|\bzoom\b/i.test(relevanceText)) {
+    return null;
+  }
+
+  if (!matchesKeywordIntent(relevanceText, keyword)) {
+    return null;
+  }
+
+  if (matchesExcludeKeywords(relevanceText, excludeKeywords)) {
+    return null;
+  }
+
+  if (!matchesRequestedLocation(eventLocation, location)) {
+    return null;
+  }
+
+  const descriptionParts = [
+    `Event: ${title}`,
+    `When: ${dateTime}`,
+    `Where: ${eventLocation}`,
+    `Matched topic: ${keyword}`,
+  ];
+
+  return {
+    id: eventId,
+    title,
+    date: dateTime,
+    time: "TBD",
+    location: eventLocation,
+    description: descriptionParts.join(" | ").slice(0, 500),
+    url: eventUrl,
+    source: "eventbrite",
+  };
 }
 
 async function fetchEventsForLocation(
   location: string,
   keyword: string,
+  timeoutMs: number,
 ): Promise<GrabbedEvent[]> {
-  const events: GrabbedEvent[] = [];
+  const eventsById = new Map<string, GrabbedEvent>();
+  const excludeKeywords = getConfiguredExcludeKeywords();
 
   try {
-    const url = `https://www.eventbrite.com/d/${location}/${keyword}/`;
-    
-    const res = await fetch(url, {
+    const locationSlug = toEventbriteSlug(location);
+    const keywordSlug = toEventbriteSlug(keyword);
+    if (!locationSlug || !keywordSlug) {
+      return [];
+    }
+
+    const url = `https://www.eventbrite.com/d/${locationSlug}/${keywordSlug}/`;
+
+    const res = await fetchWithTimeout(url, {
       headers: {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
       },
-    });
+    }, timeoutMs);
 
     if (!res.ok) {
       console.error(`Failed to fetch ${url}: ${res.status}`);
-      return events;
+      return [];
     }
 
     const html = await res.text();
 
-    // First: get all unique event URLs
-    const urlRegex = /href="(https:\/\/www\.eventbrite\.com\/e\/[^"]+)"/g;
-    const seenUrls = new Set<string>();
-    const eventUrls: string[] = [];
-    let match;
+    // Parse result blocks from search-event list items; they are more stable than generic event-card wrappers.
+    const resultRegex = /<li[\s\S]*?data-testid="search-event"[\s\S]*?<\/li>/gi;
+    let cardMatches = html.match(resultRegex) ?? [];
 
-    while ((match = urlRegex.exec(html)) !== null) {
-      const fullUrl = match[1];
-      if (!seenUrls.has(fullUrl)) {
-        seenUrls.add(fullUrl);
-        eventUrls.push(fullUrl);
-      }
+    // Fallback parser if Eventbrite changes the outer list item wrapper.
+    if (cardMatches.length === 0) {
+      const cardRegex = /<div[^>]*\bevent-card\b[\s\S]*?<\/section><\/div>/gi;
+      cardMatches = html.match(cardRegex) ?? [];
     }
 
-    // For each URL, try to find a title nearby in the HTML
-    for (const eventUrl of eventUrls) {
-      const eventId = extractEventId(eventUrl);
-      
-      // Try to find the title by looking for the URL and getting nearby text
-      const urlIndex = html.indexOf(eventUrl);
-      if (urlIndex === -1) continue;
-      
-      // Get context around the URL (before and after)
-      const contextStart = Math.max(0, urlIndex - 300);
-      const contextEnd = Math.min(html.length, urlIndex + 300);
-      const context = html.substring(contextStart, contextEnd);
-      
-      // Try to find title in the context - look for text between > and <
-      let title = "";
-      const titleMatch = context.match(/>([^<]{5,60})</);
-      if (titleMatch) {
-        title = titleMatch[1].trim();
-      }
-      
-      // Fallback: use keyword + location if no title found
-      if (!title || title.length < 5) {
-        title = `${keyword} - ${location}`;
+    for (const card of cardMatches) {
+      const parsed = buildEventFromCard(card, location, keyword, excludeKeywords);
+      if (!parsed) {
+        continue;
       }
 
-      events.push({
-        id: eventId,
-        title: normalizeText(title),
-        date: "TBD",
-        time: "TBD",
-        location: location,
-        description: `Search: ${keyword} in ${location}`,
-        url: eventUrl,
-        source: "eventbrite",
-      });
+      const existing = eventsById.get(parsed.id);
+      if (!existing) {
+        eventsById.set(parsed.id, parsed);
+        continue;
+      }
+
+      // Prefer the entry with richer fields when desktop/mobile cards duplicate the same id.
+      const existingScore =
+        (existing.date !== "TBD" ? 1 : 0) +
+        (existing.location && existing.location !== location ? 1 : 0) +
+        (existing.title.length > 12 ? 1 : 0);
+      const parsedScore =
+        (parsed.date !== "TBD" ? 1 : 0) +
+        (parsed.location && parsed.location !== location ? 1 : 0) +
+        (parsed.title.length > 12 ? 1 : 0);
+
+      if (parsedScore >= existingScore) {
+        eventsById.set(parsed.id, parsed);
+      }
     }
   } catch (e) {
     console.error(`Error fetching ${keyword} in ${location}:`, e);
   }
 
-  return events;
+  return Array.from(eventsById.values());
 }
 
-export async function grabEventbriteEvents(): Promise<GrabbedEvent[]> {
+export async function grabEventbriteEvents(
+  options: EventbriteGrabberOptions = {},
+): Promise<EventbriteGrabberRunResult> {
   const allEvents: GrabbedEvent[] = [];
   const seenIds = new Set<string>();
+  const keywords = getConfiguredKeywords();
+  const locations = getConfiguredLocations();
 
-  for (const location of US_LOCATIONS) {
-    for (const keyword of KEYWORDS) {
-      console.log(`Grabbing: ${keyword} in ${location}`);
+  const queries = locations.flatMap((location) =>
+    keywords.map((keyword) => ({ location, keyword })),
+  );
 
-      const events = await fetchEventsForLocation(location, keyword);
-      console.log(`  Found ${events.length} events`);
-
-      for (const event of events) {
-        if (!seenIds.has(event.id)) {
-          seenIds.add(event.id);
-          allEvents.push(event);
-        }
-      }
-
-      await delay(500);
-    }
+  if (queries.length === 0) {
+    return {
+      events: [],
+      attemptedQueries: 0,
+      failedQueries: 0,
+      totalQueries: 0,
+      chunkIndex: 0,
+      chunkCount: 0,
+    };
   }
 
-  console.log(`\nTotal unique events: ${allEvents.length}`);
-  return allEvents;
+  const timeoutMs = getTimeoutMs(options.timeoutMs);
+  const maxQueriesPerRun = getMaxQueriesPerRun(queries.length, options.maxQueriesPerRun);
+  const chunkCount = Math.max(1, Math.ceil(queries.length / maxQueriesPerRun));
+  const baseChunkIndex = getChunkIndex(chunkCount, options.chunkIndex);
+  const chunkIndex = options.useNextChunk
+    ? (baseChunkIndex + 1) % chunkCount
+    : baseChunkIndex;
+  const chunkStart = chunkIndex * maxQueriesPerRun;
+  const selectedQueries = queries.slice(chunkStart, chunkStart + maxQueriesPerRun);
+  let failedQueries = 0;
+
+  for (const { location, keyword } of selectedQueries) {
+    const events = await fetchEventsForLocation(location, keyword, timeoutMs);
+    if (events.length === 0) {
+      failedQueries += 1;
+    }
+
+    for (const event of events) {
+      if (!seenIds.has(event.id)) {
+        seenIds.add(event.id);
+        allEvents.push(event);
+      }
+    }
+
+    await delay(300);
+  }
+
+  return {
+    events: allEvents,
+    attemptedQueries: selectedQueries.length,
+    failedQueries,
+    totalQueries: queries.length,
+    chunkIndex,
+    chunkCount,
+  };
 }
 
 export function getEventbriteKeywords(): string[] {
-  return KEYWORDS;
+  return getConfiguredKeywords();
 }
 
 export function getEventbriteLocations(): string[] {
-  return US_LOCATIONS;
+  return getConfiguredLocations();
 }

--- a/app/lib/integrations/eventbriteGrabberSync.ts
+++ b/app/lib/integrations/eventbriteGrabberSync.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "crypto";
 import pool from "../db";
-import { grabEventbriteEvents, type GrabbedEvent } from "./eventbriteGrabber";
+import {
+  grabEventbriteEvents,
+  type EventbriteGrabberOptions,
+  type GrabbedEvent,
+} from "./eventbriteGrabber";
 
 export type EventbriteSyncResult = {
   ok: boolean;
@@ -10,6 +14,11 @@ export type EventbriteSyncResult = {
   created: number;
   updated: number;
   unchanged: number;
+  attemptedQueries?: number;
+  failedQueries?: number;
+  totalQueries?: number;
+  chunkIndex?: number;
+  chunkCount?: number;
   error?: string;
 };
 
@@ -19,6 +28,11 @@ export type EventbriteSyncTotals = {
   updated: number;
   unchanged: number;
 };
+
+export type EventbriteSyncRequest = Pick<
+  EventbriteGrabberOptions,
+  "chunkIndex" | "maxQueriesPerRun" | "timeoutMs" | "useNextChunk"
+>;
 
 async function ensureSourceColumns() {
   await pool.query(`
@@ -78,7 +92,7 @@ async function upsertEventbriteEvent(
         event.time,
         event.location,
         event.description,
-        event.description,
+        "",
         "Eventbrite",
         "See website",
         event.url,
@@ -116,7 +130,7 @@ async function upsertEventbriteEvent(
       event.time,
       event.location,
       event.description,
-      event.description,
+      "",
     ],
   );
 
@@ -130,7 +144,9 @@ function getErrorMessage(error: unknown): string {
   return "Unknown Eventbrite grabber error";
 }
 
-export async function runEventbriteGrabberSync(): Promise<EventbriteSyncResult> {
+export async function runEventbriteGrabberSync(
+  request: EventbriteSyncRequest = {},
+): Promise<EventbriteSyncResult> {
   try {
     await ensureSourceColumns();
   } catch (error) {
@@ -150,14 +166,22 @@ export async function runEventbriteGrabberSync(): Promise<EventbriteSyncResult> 
   let created = 0;
   let updated = 0;
   let unchanged = 0;
+  let attemptedQueries = 0;
+  let failedQueries = 0;
+  let totalQueries = 0;
+  let chunkIndex = 0;
+  let chunkCount = 0;
 
   try {
-    console.log("Starting Eventbrite grabber sync...");
-
-    const events = await grabEventbriteEvents();
+    const grabResult = await grabEventbriteEvents(request);
+    const events = grabResult.events;
+    attemptedQueries = grabResult.attemptedQueries;
+    failedQueries = grabResult.failedQueries;
+    totalQueries = grabResult.totalQueries;
+    chunkIndex = grabResult.chunkIndex;
+    chunkCount = grabResult.chunkCount;
 
     fetched = events.length;
-    console.log(`Grabbed ${fetched} events from Eventbrite`);
 
     for (const event of events) {
       try {
@@ -183,18 +207,28 @@ export async function runEventbriteGrabberSync(): Promise<EventbriteSyncResult> 
       created,
       updated,
       unchanged,
+      attemptedQueries,
+      failedQueries,
+      totalQueries,
+      chunkIndex,
+      chunkCount,
       error: getErrorMessage(error),
     };
   }
 
   return {
     ok: true,
-    message: "Eventbrite grabber sync completed",
+    message: "Eventbrite grabber sync completed (partial chunk)",
     source: "grabber",
     fetched,
     created,
     updated,
     unchanged,
+    attemptedQueries,
+    failedQueries,
+    totalQueries,
+    chunkIndex,
+    chunkCount,
   };
 }
 

--- a/app/opportunities/page.tsx
+++ b/app/opportunities/page.tsx
@@ -3,6 +3,7 @@ import Footer from "@/components/Footer";
 import { getAllInternships } from "@/app/lib/models/Internship";
 import { auth0 } from "@/lib/auth0";
 import pool from "@/lib/db";
+import Link from "next/link";
 import OpportunitiesList from "./OpportunitiesList";
 
 export const dynamic = "force-dynamic";
@@ -94,6 +95,15 @@ export default async function OpportunitiesPage() {
           </div>
 
           <OpportunitiesList internships={internships} userHints={userHints} />
+
+          <div className="mt-10 flex justify-center">
+            <Link
+              href="/manage-internships"
+              className="inline-flex items-center rounded-lg bg-green-600 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+            >
+              Manage &amp; Sync Jobs/Internships
+            </Link>
+          </div>
         </div>
       </main>
 

--- a/app/student/events/[id]/page.tsx
+++ b/app/student/events/[id]/page.tsx
@@ -54,7 +54,9 @@ export default async function EventDetailsPage({ params }: PageProps) {
 
           <div className="text-gray-700 dark:text-gray-200 leading-relaxed space-y-3">
             <p>{event.description}</p>
-            <p>{event.details}</p>
+            {event.details && event.details.trim() !== event.description.trim() ? (
+              <p>{event.details}</p>
+            ) : null}
           </div>
 
           <div className="grid gap-4 sm:grid-cols-2">

--- a/middleware.ts
+++ b/middleware.ts
@@ -32,7 +32,14 @@ function hasAuth0Config() {
 }
 
 export async function middleware(request: NextRequest) {
+  const isApiRoute = request.nextUrl.pathname.startsWith("/api/");
   const isAuthRoute = request.nextUrl.pathname.startsWith("/auth/");
+
+  // Keep API responses API-shaped (JSON/status codes) by letting route handlers
+  // enforce auth instead of redirecting to HTML from middleware.
+  if (isApiRoute) {
+    return NextResponse.next();
+  }
 
   // When Auth0 is not configured, redirect auth routes to the login page
   // instead of letting them 404 or hit a broken Auth0 SDK.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,12 @@
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.2.0",
         "next": "^15.5.12",
+        "node-ical": "^0.26.0",
         "pg": "^8.16.3",
         "react": "^19.2.1",
         "react-datepicker": "^8.8.0",
-        "react-dom": "^19.2.1"
+        "react-dom": "^19.2.1",
+        "rss-parser": "^3.13.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -2587,6 +2589,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2829,7 +2843,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -9657,6 +9671,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
+    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -10864,6 +10884,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-ical": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.26.0.tgz",
+      "integrity": "sha512-tJZY2fMb38Gbj0P05zHMWBr90MslhGZ1qEbOWYnokBYPPX/lYskL/0NnWoeiXTBNod+kRRcTOjxAeB20kfvKyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rrule-temporal": "^1.5.1",
+        "temporal-polyfill": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11507,7 +11540,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "playwright-core": "1.59.1"
       },
@@ -11525,7 +11558,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -12025,12 +12058,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rrule-temporal": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.5.2.tgz",
+      "integrity": "sha512-I5rAiZfRlMh0vuG23HrGBMLZOSiQO7H1Uq8l9qyfA6oTD5j+UMRwpRs4aVU4XdaFhgN1p3K+cHelG8KvLTTm+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rss-parser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
+      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.5.0"
+      }
+    },
+    "node_modules/rss-parser/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -12147,6 +12208,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -13000,6 +13070,21 @@
       "dependencies": {
         "streamx": "^2.12.5"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.1"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -13903,6 +13988,28 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.2.0",
     "next": "^15.5.12",
+    "node-ical": "^0.26.0",
     "pg": "^8.16.3",
     "react": "^19.2.1",
     "react-datepicker": "^8.8.0",
-    "react-dom": "^19.2.1"
+    "react-dom": "^19.2.1",
+    "rss-parser": "^3.13.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
   "regions": ["iad1"],
   "crons": [
     {
+      "path": "/api/cron/events-prune",
+      "schedule": "0 8 * * *"
+    },
+    {
       "path": "/api/cron/greenhouse-sync",
       "schedule": "0 10 * * *"
     },
@@ -17,6 +21,10 @@
     {
       "path": "/api/cron/eventbrite-sync",
       "schedule": "0 10 * * *"
+    },
+    {
+      "path": "/api/cron/community-events-sync",
+      "schedule": "0 9 * * *"
     }
   ],
   "redirects": [


### PR DESCRIPTION
- Implemented POST endpoint for community event sync at /api/events/community/sync
- Implemented POST endpoint for community reset sync at /api/events/community/reset-sync
- Implemented POST endpoint for eventbrite reset sync at /api/events/eventbrite/reset-sync
- Added community feed synchronization logic in app/lib/integrations/communityFeedSync.ts
- Added event pruning logic in app/lib/integrations/eventPrune.ts
- Introduced utility functions for parsing and processing community feed events
- Enhanced database schema for events to support new sources and external IDs
- Added error handling and logging for sync operations